### PR TITLE
Modify debug output

### DIFF
--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -49,6 +49,7 @@ class Tuner(object):
         self.best_flops = 0
         self.best_measure_pair = None
         self.best_iter = 0
+        self.error_ct_threshold = 150
 
         # time to leave
         self.ttl = None
@@ -138,6 +139,7 @@ class Tuner(object):
                 if res.error_no == 0:
                     flops = inp.task.flop / np.mean(res.costs)
                     error_ct = 0
+                    result_msg = res
                 else:
                     flops = 0
                     error_ct += 1
@@ -146,6 +148,7 @@ class Tuner(object):
                         errors.append(tb + "\n" + error)
                     else:
                         errors.append(tb + "\n" + str(error))
+                    result_msg = errors[-1]
 
                 if flops > self.best_flops:
                     self.best_flops = flops
@@ -159,9 +162,9 @@ class Tuner(object):
                     si_prefix,
                     format_si_prefix(flops, si_prefix),
                     format_si_prefix(self.best_flops, si_prefix),
-                    res,
+                    result_msg,
                     config,
-                )
+                    )
 
             i += len(results)
             self.ttl = min(early_stopping + self.best_iter, n_trial) - i
@@ -174,7 +177,7 @@ class Tuner(object):
                 logger.debug("Early stopped. Best iter: %d.", self.best_iter)
                 break
 
-            if error_ct > 150:
+            if error_ct > self.error_ct_threshold:
                 logging.basicConfig()
                 logger.warning("Too many errors happen in the tuning. Switching to debug mode.")
                 logger.setLevel(logging.DEBUG)
@@ -214,3 +217,12 @@ class Tuner(object):
             will be done.
         """
         raise NotImplementedError()
+
+    def set_error_threshold(self, threshold):
+        """Modify error counter threshold, which controls switch to debug mode
+
+        Parameters
+        ----------
+        threshold: New threshold value
+        """
+        self.error_ct_threshold = threshold


### PR DESCRIPTION
Currently in some cases debug messages are shown in a unformatted way as shown below.

```
DEBUG:autotvm:No: 151	GFLOPS: 0.00/0.00	result: MeasureResult(costs=('Traceback (most recent call last):\n  [bt] (8) /path/tvm/build/libtvm.so(TVMFuncCall+0x63) [0x7f2995ef4fa3]\n  [bt] (7) /path/tvm/build/libtvm.so(+0x1619457) [0x7f2995f65457]\n  [bt] (6) /path/tvm/build/libtvm.so(tvm::runtime::RPCWrappedFunc::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const+0x365) [0x7f2995f6bd35]\n  [bt] (5) /path/tvm/build/libtvm.so(tvm::runtime::RPCClientSession::CallFunc(void*, TVMValue const*, int const*, int, std::function<void (tvm::runtime::TVMArgs)> const&)+0x57) [0x7f2995f5dcf7]\n  [bt] (4) /path/tvm/build/libtvm.so(tvm::runtime::RPCEndpoint::CallFunc(void*, TVMValue const*, int const*, int, std::function<void (tvm::runtime::TVMArgs)>)+0x515) [0x7f2995f51f95]\n  [bt] (3) /path/tvm/build/libtvm.so(tvm::runtime::RPCEndpoint::HandleUntilReturnEvent(bool, std::function<void (tvm::runtime::TVMArgs)>)+0x2d5) [0x7f2995f50f95]\n  [bt] (2) /path/tvm/build/libtvm.so(tvm::runtime::RPCEndpoint::EventHandler::HandleNextEvent(bool, bool, std::function<void (tvm::runtime::TVMArgs)>)+0x459) [0x7f2995f5dac9]\n  [bt] (1) /path/tvm/build/libtvm.so(tvm::runtime::RPCEndpoint::EventHandler::HandleReturn(tvm::runtime::RPCCode, std::function<void (tvm::runtime::TVMArgs)>)+0x13c) [0x7f2995f5c8dc]\n  [bt] (0) /path/tvm/build/libtvm.so(+0x1602e78) [0x7f2995f4ee78]\n  File "/path/tvm/src/runtime/opencl/opencl_module.cc", line 240\n  File "/path/tvm/src/runtime/rpc/rpc_endpoint.cc", line 378\nRPCError: Error caught from RPC call:\n[18:13:48] /path/tvm/src/runtime/library_module.cc:78: \n---------------------------------------------------------------\nAn internal invariant was violated during the execution of TVM.\nPlease read TVM\'s error reporting guidelines.\nMore details can be found here: https://discuss.tvm.ai/t/error-reporting/7793.\n---------------------------------------------------------------\n\n  Check failed: ret == 0 (-1 vs. 0) : TVMError: OpenCL build error for device=0x6d783918c8\nBC-src-code:9:110: error: expected \')\'\n__kernel void default_function_kernel1(__write_only image2d_t kernel_texture_weight, __global half* restrict kernel) {\n                                                                                                             ^\nBC-src-code:9:39: note: to match this \'(\'\n__kernel void default_function_kernel1(__write_only image2d_t kernel_texture_weight, __global half* restrict kernel) {\n                                      ^\nBC-src-code:9:110: error: parameter name omitted\n__kernel void default_function_kernel1(__write_only image2d_t kernel_texture_weight, __global half* restrict kernel) {\n                                                                                                             ^\nBC-src-code:10:158: error: expected expression\n  (void)write_imageh(kernel_texture_weight, (int2)((((int)get_local_id(0)) % 27), ((((int)get_group_id(0)) * 2) + (((int)get_local_id(0)) / 27))), vload4(0, kernel + ((((int)get_group_id(0)) * 216) + (((int)get_local_id(0)) * 4))));\n                                                                                                                                                             ^\n3 diagnostic(s) generated.',), error_no=7, all_cost=15, timestamp=1645715629.9118824)	[('tile_fc', [-1, 1, 8]), ('tile_y', [-1, 7, 8]), ('tile_x', [-1, 4, 2]), ('tile_rcc', [-1, 1]), ('tile_ry', [-1, 3]), ('tile_rx', [-1, 1]), ('auto_unroll_max_step', 512), ('unroll_explicit', 0)],None,14882
```
This PR makes the following changes:

1. Modify debug output to make it more readable
2. Replace magic number with a variable `error_ct_threshold`
3. Add function to set error counter threshold externally for debug purposes
